### PR TITLE
Replace deprecated addPanel method

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -10,7 +10,7 @@ export function register () {
     const channel = addons.getChannel()
     setDirectionOnStoryChange(api)
 
-    addons.addPanel(PANEL_ID, {
+    addons.add(PANEL_ID, {
       title: 'RTL',
       render: ({ active, key }) => { /* eslint-disable-line react/prop-types, react/display-name */
         if (!active) {


### PR DESCRIPTION
As mentioned here: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#addon-api-is-more-type-strict, `addons.addPanel` has been deprecated in v7 and is removed in v8. 

Replacing it with `addons.add` fixes the issue and makes things work in v8 alpha 10.