### PR TITLE
feat: support docs (quick-and-dirty way)

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -13,9 +13,6 @@ addons.register(ADDON_ID, (api) => {
     type: types.TOOL,
     title: "RTL",
     disabled: true,
-    match: ({ viewMode }) => {
-      return viewMode === "story";
-    },
     render: Tool,
   });
 });


### PR DESCRIPTION
I don't intend to merge this as-is (see my comment in #12 for more thoughts on how I want to do it), but if someone really wants doc support, you can install the canary version.

Relates to #12 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.0--canary.28.e57ada5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-rtl@1.1.0--canary.28.e57ada5.0
  # or 
  yarn add storybook-addon-rtl@1.1.0--canary.28.e57ada5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
