### PR TITLE
Use Globals API

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,9 @@
 import type { Preview } from "@storybook/react";
 
 const preview: Preview = {
+  initialGlobals: {
+    addonRtl: "ltr",
+  },
   parameters: {
     backgrounds: {
       default: "light",

--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ This addon uses the [Storybook Channel API](https://storybook.js.org/docs/addons
 ## License
 
 Copyright (c) 2023 Benjamin Kindle (@literalpie). This is free software, and may be redistributed under the terms specified in the LICENSE file.
+
+# Choices
+
+- Make a breaking change, all in on globals. Already go to 2.0 dropping paramters support
+- Ship in state where initialGlobals does not work on non-docs stories. Docs will get direction from whatever happened to be the last story you were on :-/
+- Use globals as a fallback value. The globals value gets updated when any change happens (eg. story has parameters), which will cause all later viewed stories to use that globals value.
+- Opt in to globals. I'd have to figure out how to refactor to support both ways. - I'd rather just say stay on 1.0 if you want to keep the old way.
+
+I think I want to do the 2.0 way.

--- a/package.json
+++ b/package.json
@@ -130,5 +130,8 @@
       "first-time-contributor"
     ]
   },
-  "packageManager": "pnpm@9.12.3+sha256.24235772cc4ac82a62627cd47f834c72667a2ce87799a846ec4e8e555e2d4b8b"
+  "packageManager": "pnpm@9.12.3+sha256.24235772cc4ac82a62627cd47f834c72667a2ce87799a846ec4e8e555e2d4b8b",
+  "dependencies": {
+    "@storybook/test": "^8.4.1"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@storybook/test':
+        specifier: ^8.4.1
+        version: 8.4.1(storybook@8.4.1(prettier@3.3.3))
     devDependencies:
       '@auto-it/conventional-commits':
         specifier: ^11.3.0

--- a/src/components/Tool.tsx
+++ b/src/components/Tool.tsx
@@ -1,30 +1,36 @@
-import React, { useState } from "react";
-import { useChannel } from "@storybook/manager-api";
-import { RTLDirection, UPDATE_EVENT_ID } from "src/constants";
+import React from "react";
+import {
+  useChannel,
+  useGlobals,
+  useStorybookApi,
+} from "@storybook/manager-api";
+import { UPDATE_EVENT_ID } from "src/constants";
 import { IconButton } from "@storybook/components";
 import { DirectionArrowsIcon } from "./DirectionArrowsIcon";
 
 export const Tool = () => {
-  const [dirState, setDirState] = useState<{ direction: RTLDirection }>({
-    direction: "ltr",
-  });
-  const channel = useChannel({
-    [UPDATE_EVENT_ID]: (updateEvent) => {
-      setDirState({ direction: updateEvent.direction });
-    },
-  });
+  const channel = useChannel({});
+  const [globals] = useGlobals();
+  const storyGlobals = useStorybookApi().getStoryGlobals();
+  console.log("story", storyGlobals);
   return (
     <>
+      blah
       <IconButton
-        placeholder={"Text Direction"}
+        disabled={storyGlobals.addonRtl !== undefined}
+        aria-label="Text Direction"
         onClick={() => {
+          const newDirection = globals.addonRtl === "rtl" ? "ltr" : "rtl";
+          // The value needs to be set with the event like this so we can include userInteraction: true
+          // so it will take higher priority that story change events.
+          // The listener added in manager.ts will make sure the value makes its way to "globals"
           channel(UPDATE_EVENT_ID, {
-            direction: dirState.direction === "rtl" ? "ltr" : "rtl",
+            direction: newDirection,
             userInteraction: true,
           });
         }}
       >
-        <DirectionArrowsIcon direction={dirState.direction} />
+        <DirectionArrowsIcon direction={globals.addonRtl} />
       </IconButton>
     </>
   );

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,7 +1,12 @@
 import { API, addons, types } from "@storybook/manager-api";
-import { ADDON_ID, RTLDirection, TOOL_ID, UPDATE_EVENT_ID } from "./constants";
+import {
+  ADDON_ID,
+  INITIALIZE_EVENT_ID,
+  RTLDirection,
+  TOOL_ID,
+  UPDATE_EVENT_ID,
+} from "./constants";
 import { getDefaultTextDirection } from "./utils";
-import { STORY_RENDERED } from "@storybook/core-events";
 import { Tool } from "./components/Tool";
 
 addons.register(ADDON_ID, (api) => {
@@ -13,9 +18,6 @@ addons.register(ADDON_ID, (api) => {
     type: types.TOOL,
     title: "RTL",
     disabled: true,
-    match: ({ viewMode }) => {
-      return viewMode === "story";
-    },
     render: Tool,
   });
 });
@@ -25,18 +27,27 @@ export function setDirectionOnStoryChange(api: API) {
   // Keep track of the most recent value that was a result of user interaction
   // so we can return to this value whenever a story is opened that does not have a parameter
   let lastUserInteractionValue: RTLDirection;
-  // Whenever a story is rendered, update the state to represent the parameter value of the story.
-  // We do this here and not in the panel component because we want the parameter to be respected
-  // even if the panel is never opened
-  channel.on(STORY_RENDERED, () => {
+
+  channel.on(UPDATE_EVENT_ID, (event) => {
+    const newDirection = event.direction;
+    if (api.getGlobals().addonRtl !== newDirection) {
+      api.updateGlobals({ addonRtl: newDirection });
+    }
+  });
+  // Whenever a story is initialized, update the state to represent the parameter value of the story.
+  channel.on(INITIALIZE_EVENT_ID, () => {
     const lastUpdate = channel.last(UPDATE_EVENT_ID)?.[0];
     lastUserInteractionValue = lastUpdate?.userInteraction
       ? lastUpdate.direction
       : lastUserInteractionValue;
 
     const paramValue = api.getCurrentParameter("direction");
+    const storyGlobal = api.getStoryGlobals().addonRtl;
     let newDirection;
-    if (paramValue) {
+    // storyGlobal gets the highest precedence because if it is set, the value of global cannot be changed.
+    if (storyGlobal !== undefined) {
+      newDirection = storyGlobal;
+    } else if (paramValue) {
       newDirection = paramValue;
     } else if (lastUserInteractionValue) {
       newDirection = lastUserInteractionValue;

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,10 +1,26 @@
-import { Meta } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./Button";
+import { expect, within } from "@storybook/test";
+import { getElementDirection } from "./utils";
+
 export default {
   component: Button,
+  tags: ["autodocs"],
 } satisfies Meta;
 
-export const standard = {};
+export const standard = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.findByText("Click Me!");
+    expect(getElementDirection(await button)).toEqual("ltr");
+  },
+} satisfies StoryObj;
+
 export const RTL = {
-  parameters: { direction: "rtl" },
-};
+  globals: { addonRtl: "rtl" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.findByText("Click Me!");
+    expect(getElementDirection(await button)).toEqual("rtl");
+  },
+} satisfies StoryObj;

--- a/src/stories/CustomDecorator.stories.tsx
+++ b/src/stories/CustomDecorator.stories.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from "react";
-import { useChannel } from "@storybook/preview-api";
+import React from "react";
+import { useChannel, useState } from "@storybook/preview-api";
 import { RTL_UPDATE_EVENT, RTLChangeEvent } from "../index";
 import { Decorator, Meta } from "@storybook/react";
+import { within, userEvent, expect } from "@storybook/test";
+import { getElementDirection } from "./utils";
 
 const SimpleText = () => {
   return <div>This is some example text</div>;
@@ -38,4 +40,19 @@ export const CustomDecorator = {};
 export default {
   decorators: [withDirectionToggle],
   component: SimpleText,
+} satisfies Meta;
+
+export const TestToggle = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(getElementDirection(canvasElement)).toBe("ltr");
+    canvas.findByText("The direction is ltr");
+
+    const button = await canvas.findByText("Toggle Direction");
+
+    await userEvent.click(button);
+    await canvas.findByText("The direction is rtl");
+    expect(getElementDirection(canvasElement)).toBe("rtl");
+  },
 } satisfies Meta;

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -1,0 +1,3 @@
+export const getElementDirection = (element: HTMLElement) => {
+  return (element.computedStyleMap().get("direction") as CSSKeywordValue).value;
+};

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { API } from "@storybook/manager-api";
-import { getDefaultTextDirection, setTextDirection } from "./utils";
+import { getDefaultTextDirection } from "./utils";
 import { describe, test, expect, vi } from "vitest";
 
 describe("utils", () => {
@@ -8,19 +8,10 @@ describe("utils", () => {
     test("returns the text direction from the query params", () => {
       const api = {
         getQueryParam: vi.fn().mockReturnValue("rtl"),
+        getGlobals: vi.fn().mockReturnValue("ltr"),
       };
       vi.spyOn<any, any>(window, "getComputedStyle").mockReturnValue({
         direction: "",
-      });
-      expect(getDefaultTextDirection(api as unknown as API)).toBe("rtl");
-    });
-
-    test("returns the text direction from the html tag", () => {
-      const api = {
-        getQueryParam: vi.fn().mockReturnValue(undefined),
-      };
-      vi.spyOn<any, any>(window, "getComputedStyle").mockReturnValue({
-        direction: "rtl",
       });
       expect(getDefaultTextDirection(api as unknown as API)).toBe("rtl");
     });
@@ -28,18 +19,12 @@ describe("utils", () => {
     test("returns `ltr` as a fallback", () => {
       const api = {
         getQueryParam: vi.fn().mockReturnValue(undefined),
+        getGlobals: vi.fn().mockReturnValue("ltr"),
       };
       vi.spyOn<any, any>(window, "getComputedStyle").mockReturnValue({
         direction: "",
       });
       expect(getDefaultTextDirection(api as unknown as API)).toBe("ltr");
-    });
-  });
-
-  describe(".setTextDirection", () => {
-    test("sets the direction of the html tag", () => {
-      setTextDirection("rtl");
-      expect(document.documentElement.dir).toBe("rtl");
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,9 @@
 import { API } from "@storybook/manager-api";
-import { RTLDirection } from "./constants";
 
 export function getDefaultTextDirection(api: API) {
   const queryParam = api.getQueryParam("direction");
   const htmlDirection = window
     .getComputedStyle(document.documentElement)
     .direction.toLowerCase();
-  return queryParam || htmlDirection || "ltr";
-}
-
-export function setTextDirection(direction: RTLDirection) {
-  document.documentElement.dir = direction;
+  return queryParam || api.getGlobals().addonRtl || htmlDirection || "ltr";
 }


### PR DESCRIPTION
This is a draft. The current code was still trying to maintain compatibility, but I don't think that's worth it. We should just jump to 2.0 even though 1.0 isn't that old.

* Disable the toggle button when storyGlobals is set
* The global will be called addonRtl
* We respect URL params, but also the globals api has its own version of url params
* Events still work the same as before

Fixes #27 