### PR TITLE
chore: support auto prerelease branch

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,9 @@
+{
+  "prereleaseBranches": ["next"],
+  "plugins": [
+    "npm",
+    "git",
+    "conventional-commits",
+    "first-time-contributor"
+  ]
+}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.32.1d43ec8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-rtl@2.0.0--canary.32.1d43ec8.0
  # or 
  yarn add storybook-addon-rtl@2.0.0--canary.32.1d43ec8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
